### PR TITLE
Fixed: Links in kvitter feed allowed to flow outside container

### DIFF
--- a/app/assets/stylesheets/kvitters.css.scss
+++ b/app/assets/stylesheets/kvitters.css.scss
@@ -8,6 +8,10 @@
   padding: 0;
 }
 
+#kvitter ul li {
+  overflow: hidden;
+}
+
 .kvitter-btn {
   margin-top: 1em;
 }


### PR DESCRIPTION
Added overflow:hidden on the #kvitter li-tag
